### PR TITLE
Add clean-up code & update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,13 @@ running:
 
 	$ docker inspect oc-openchange | grep IPAddress
 
-For instance, if our container's address is
-`172.17.0.2`, we will have to add to the *hosts* file the following line:
+For instance, if our container's address is `172.17.0.2`, we will have to add
+to the *hosts* file the following line:
 
     172.17.0.2                openchange.zentyal.lan
 
+Another way of establishing this connection is by changing the DNS server
+address of your Windows machine to the `oc-openchange` container's address.
 
 Apply changes
 -------------
@@ -72,6 +74,7 @@ The REST API backend can be deprovisioned and reprovisioned by killing the
 Samba process in `oc-openchange` and running:
 
     $ /usr/lib/python2.7/dist-packages/openchange/backends/rest.py --deprovision --username=openchange
+    $ /usr/lib/python2.7/dist-packages/openchange/backends/rest.py --provision --username=openchange
     $ make run
 
 Note

--- a/openchange/Makefile
+++ b/openchange/Makefile
@@ -9,6 +9,7 @@ openchange: install provision run
 
 restserver: install
 	echo 'HOST="0.0.0.0"' > /restserver.cfg
+	rm -f /openchange/python/mock/rest/temp/*
 	API_SERVER_SETTINGS=/restserver.cfg python /openchange/python/mock/rest/api_server.py
 
 provision:
@@ -28,6 +29,7 @@ provision:
 	/usr/bin/samba-tool user create openchange openchange
 	/usr/sbin/openchange_newuser --enable --create openchange
 	cat /openchange_provision.sql | mysql -h $(MYSQL_HOST) -u root -p$(MYSQL_ROOT_PASSWORD) openchange
+	/usr/lib/python2.7/dist-packages/openchange/backends/rest.py --deprovision --username=openchange
 	/usr/lib/python2.7/dist-packages/openchange/backends/rest.py --provision --username=openchange
 
 .openchange-autogen:


### PR DESCRIPTION
- `e68dd54` includes another way of establishing the communication between Outlook and OpenChange and corrects a typo.
- `e85ae01` adds two lines in the OpenChange container's Makefile so `make  restserver` and `make provision` clean up the temporary files. 
